### PR TITLE
Use less-specific version numbers for requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
 	],
 	"require": {
 		"php": ">=5.5.9",
-		"symfony/console": "^3.3.5"
+		"symfony/console": "^3.3"
 	},
 	"require-dev": {
-		"jakub-onderka/php-parallel-lint": "0.9.2",
-		"jakub-onderka/php-console-highlighter": "0.3.2",
-		"mediawiki/mediawiki-codesniffer": "0.12.0"
+		"jakub-onderka/php-parallel-lint": "^0.9",
+		"jakub-onderka/php-console-highlighter": "^0.3",
+		"mediawiki/mediawiki-codesniffer": "^15.0"
 	},
 	"scripts": {
 		"test": [


### PR DESCRIPTION
I was trying to install this in a project that was already using symfony/console, but it wouldn't let me because of a mismatch in the minor version numbers.